### PR TITLE
[feat] add "app" to sequelize instances.

### DIFF
--- a/lib/SequelizeResolver.ts
+++ b/lib/SequelizeResolver.ts
@@ -44,12 +44,16 @@ export class SequelizeResolver extends FabrixResolver {
   }
 
   public connect(modelName, schema, options) {
+    // Define the Sequelize Connection on the provided connection
     this._sequelizeModel = this._connection.define(modelName, schema, options)
+    // Add a copy of the Fabrix app to the connection model
     this._sequelizeModel.app = this.app
 
+    // A helpful exposure of the instance of Sequelize being used
     this._sequelize = this._sequelizeModel.sequelize
     this.model.datastore = this.model['sequelize'] = this.datastore
 
+    // Get the instance methods
     const instanceMethods = Transformer.getModelPrototypes(this.model)
     const classMethods = Transformer.getModelMethods(this.model, instanceMethods)
 
@@ -63,10 +67,13 @@ export class SequelizeResolver extends FabrixResolver {
       this._sequelizeModel.prototype[i] = instanceMethods[i]
     })
 
+    // Attach Fabrix to the instance prototype
+    this._sequelizeModel.prototype.app = this.app
+
     // Add this model to the connection.models for use later
     this._connection.models[modelName] = this._sequelizeModel
 
-    // Bind the new methods to the models
+    // Bind the new methods to the Fabrix model
     const resolverMethods = Transformer.getClassMethods(this)
     Object.entries(resolverMethods).forEach(([ _, method]: [any, string])  => {
       this.model[method] = this[method].bind(this)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@fabrix/spool-sequelize",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fabrix/spool-sequelize",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Spool - Datastore Spool for Sequelize.js http://sequelizejs.com",
   "scripts": {
     "build": "tsc -p ./lib/tsconfig.release.json",

--- a/test/integrations/spool.test.js
+++ b/test/integrations/spool.test.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const assert = require('assert')
+const Transformer = require('../../dist/transformer').Transformer
 
 describe('Spool', () => {
   let spool
@@ -40,7 +41,8 @@ describe('Spool', () => {
   it('should access a instanceLevelMethod', (done) => {
     const instance = global.app.models.testModel.build({name: 'test'})
     assert.equal(instance.instanceLevelMethod(), 'bar')
-    // assert.ok(instance.app)
+    assert.ok(instance.app)
+    assert.ok(instance.app.config.get('main'))
     done()
   })
 


### PR DESCRIPTION
#### Description
Adds `app` to model instance prototype.  For example Instance.app returns the fabrix app.

#### Issues
- resolves none
