### PR TITLE
#19 support include objects using associate property

### DIFF
--- a/lib/api/services/SequelizeService.ts
+++ b/lib/api/services/SequelizeService.ts
@@ -55,8 +55,15 @@ export class SequelizeService extends Service {
     }
 
     overrides.map(include => {
-      const inIncludes = includes.findIndex(i => i.model === include.model)
-      if (inIncludes !== -1 && includes[inIncludes]['as'] === include.as) {
+      const inIncludes = include.model
+        ? includes.findIndex(i => ((i.model === include.model) && (i.as === include.as))
+          || (include.model.name &&
+            ((i.associate && i.associate.source.name) === (include.model.name))))
+        : includes.findIndex(i => (i.association === include.association)
+          || (include.association.source.name &&
+            ((i.model && i.model.name) === include.association.source.name)))
+
+      if (inIncludes !== -1) {
         includes[inIncludes] = include
       }
       else {

--- a/test/unit/services/SequelizeService.test.js
+++ b/test/unit/services/SequelizeService.test.js
@@ -91,4 +91,38 @@ describe('api.services.SequelizeService', () => {
     assert.equal(newOptions.hello, 'world')
     done()
   })
+  it('should replace model with association that match', (done) => {
+    const name = 'hello';
+    const newOptions = global.app.services.SequelizeService.mergeOptionDefaults({
+      include: [{ model: {name} }]
+    }, {
+        include: [{ associate: {source: {name} }}
+      ]
+    })
+    assert.equal(newOptions.include.length, 1)
+    assert.equal(newOptions.include[0].associate.source.name, 'hello')
+    done()
+  })
+  it('should replace association with model that match', (done) => {
+    const name = 'hello';
+    const newOptions = global.app.services.SequelizeService.mergeOptionDefaults({
+      include: [{ associate: {source: {name}} }]
+    }, {
+        include: [{ model: {name} }]
+    })
+    assert.equal(newOptions.include.length, 1)
+    assert.equal(newOptions.include[0].model.name, 'hello')
+    done()
+  })
+  it('should merge includes when one uses model and another uses associate include formats', (done) => {
+    const newOptions = global.app.services.SequelizeService.mergeOptionDefaults({
+      include: [{associate: {source: {name: 'hello'}} }]
+    }, {
+      include: [{ model: {name: 'world'} }]
+    })
+    assert.equal(newOptions.include.length, 2)
+    assert.equal(newOptions.include[0].associate.source.name, 'hello')
+    assert.equal(newOptions.include[1].model.name, 'world')
+    done()
+  })
 })


### PR DESCRIPTION
#### Description
Modified `SequelizeService.mergeOptionIncludes` to add support for the `associate` property in the include objects which are passed in as an array.

Alternative format
```javascript
include: [
  association: model.instance.associations.[AssociationName]
]
```

#### Issues
- resolves #19
