### PR TITLE
- fix association property in mergeOpitionIncludes

### DIFF
--- a/lib/api/services/SequelizeService.ts
+++ b/lib/api/services/SequelizeService.ts
@@ -55,13 +55,25 @@ export class SequelizeService extends Service {
     }
 
     overrides.map(include => {
-      const inIncludes = include.model
-        ? includes.findIndex(i => ((i.model === include.model) && (i.as === include.as))
-          || (include.model.name &&
-            ((i.associate && i.associate.source.name) === (include.model.name))))
-        : includes.findIndex(i => (i.associate === include.associate)
-          || (include.associate.source.name &&
-            ((i.model && i.model.name) === include.associate.source.name)))
+      let inIncludes = -1
+      if (include.model) {
+        inIncludes = includes.findIndex(i => ((i.model === include.model) && (i.as === include.as))
+          || (((i.association && i.association.target) === (include.model)) && (i.association.as === include.as))
+          || ((i.target === include.model) && (i.as === include.as))
+        )
+      }
+      else if (include.association) {
+        inIncludes = includes.findIndex(i => (i.association === include.association)
+          || ((i.model === include.association.target) && (i.as === include.as))
+          || ((i.target === include.association.target) && (i.as === include.as))
+        )
+      }
+      else if (include.target) {
+        inIncludes = includes.findIndex(i => ((i.target === include.target) && (i.as === include.as))
+          || ((i.model === include.target)  && (i.as === include.as))
+          || (((i.association && i.association.target) === include.target) && (i.association.as === include.as))
+        )
+      }
 
       if (inIncludes !== -1) {
         includes[inIncludes] = include

--- a/test/unit/services/SequelizeService.test.js
+++ b/test/unit/services/SequelizeService.test.js
@@ -2,7 +2,7 @@
 
 const assert = require('assert')
 
-describe('api.services.SequelizeService', () => {
+describe.only('api.services.SequelizeService', () => {
   it.skip('should do stringify sort', (done) => {
     const sort = [['created_at','ASC']]
     const s = global.app.services.SequelizeService.sortToString(sort)
@@ -91,66 +91,95 @@ describe('api.services.SequelizeService', () => {
     assert.equal(newOptions.hello, 'world')
     done()
   })
-  it('should replace model with association that match', (done) => {
-    const name = 'hello';
+  it('should replace model with association object that match', (done) => {
     const newOptions = global.app.services.SequelizeService.mergeOptionDefaults({
-      include: [{ model: {name} }]
+      include: [{ model: 'hello' }]
     }, {
-        include: [{ associate: {source: {name} }}
-      ]
+        include: [{ target: 'hello' }]
+      })
+    assert.equal(newOptions.include.length, 1)
+    assert.equal(newOptions.include[0].target, 'hello')
+    done()
+  })
+  it('should replace association object with model that match', (done) => {
+    const newOptions = global.app.services.SequelizeService.mergeOptionDefaults({
+      include: [{ target: 'model' }}]
+    }, {
+        include: [{ model: 'model' }]
     })
     assert.equal(newOptions.include.length, 1)
-    assert.equal(newOptions.include[0].associate.source.name, 'hello')
+    assert.equal(newOptions.include[0].model, 'model')
+    done()
+  })
+
+  it('should replace model with association object that match', (done) => {
+    const newOptions = global.app.services.SequelizeService.mergeOptionDefaults({
+      include: [ {model: 'hello' }]
+    }, {
+        include: [{ target: 'hello' }]
+      })
+    assert.equal(newOptions.include.length, 1)
+    assert.equal(newOptions.include[0].target, 'hello')
+    done()
+  })
+  it('should replace model with association prop that match', (done) => {
+    const newOptions = global.app.services.SequelizeService.mergeOptionDefaults({
+      include: [{ model: 'hello' }]
+    }, {
+        include: [{ association: { target: 'hello' }}
+      ]
+      })
+    assert.equal(newOptions.include.length, 1)
+    assert.equal(newOptions.include[0].association.target, 'hello')
     done()
   })
   it('should replace association with model that match', (done) => {
-    const name = 'hello';
     const newOptions = global.app.services.SequelizeService.mergeOptionDefaults({
-      include: [{ associate: {source: {name}} }]
+      include: [{ association: { target: 'model' }}]
     }, {
-        include: [{ model: {name} }]
+        include: [{ model: 'model' }]
     })
     assert.equal(newOptions.include.length, 1)
-    assert.equal(newOptions.include[0].model.name, 'hello')
+    assert.equal(newOptions.include[0].model, 'model')
     done()
   })
   it('should merge includes when one uses model and another uses associate include formats', (done) => {
     const newOptions = global.app.services.SequelizeService.mergeOptionDefaults({
-      include: [{associate: {source: {name: 'hello'}} }]
+      include: [{association: { target: 'hello'} }]
     }, {
-      include: [{ model: {name: 'world'} }]
+      include: [{ model: 'world' }]
     })
     assert.equal(newOptions.include.length, 2)
-    assert.equal(newOptions.include[0].associate.source.name, 'hello')
-    assert.equal(newOptions.include[1].model.name, 'world')
+    assert.equal(newOptions.include[0].association.target, 'hello')
+    assert.equal(newOptions.include[1].model, 'world')
     done()
   })
-  it('should replace model with association that match with multiple include objects', (done) => {
+  it('should replace model with association prop that match with multiple include objects', (done) => {
     const newOptions = global.app.services.SequelizeService.mergeOptionDefaults({
-      include: [{ model: {name: 'hello'} }]
+      include: [{ model: 'hello' }]
     }, {
       include: [
-        {model: {name: 'world'}},
-        {associate: {source: {name: 'hello'}}}
+        {model: 'world'},
+        {association: { target: 'hello' }}
       ]
     })
     assert.equal(newOptions.include.length, 2)
-    assert.equal(newOptions.include[0].associate.source.name, 'hello')
-    assert.equal(newOptions.include[1].model.name, 'world')
+    assert.equal(newOptions.include[0].association.target, 'hello')
+    assert.equal(newOptions.include[1].model, 'world')
     done()
   })
   it('should replace association with model that match with multiple include objects', (done) => {
     const newOptions = global.app.services.SequelizeService.mergeOptionDefaults({
       include: [
-        {model: {name: 'world'}},
-        {associate: {source: {name: 'hello'}}}
+        { model: 'world' },
+        {association: { target: 'hello' }}
       ]
     }, {
-      include: [{model: {name: 'hello'}}]
+      include: [{ model: 'hello' }]
     })
     assert.equal(newOptions.include.length, 2)
-    assert.equal(newOptions.include[0].model.name, 'world')
-    assert.equal(newOptions.include[1].model.name, 'hello')
+    assert.equal(newOptions.include[0].model, 'world')
+    assert.equal(newOptions.include[1].model, 'hello')
     done()
   })
 })

--- a/test/unit/services/SequelizeService.test.js
+++ b/test/unit/services/SequelizeService.test.js
@@ -103,7 +103,7 @@ describe('api.services.SequelizeService', () => {
   })
   it('should replace association object with model that match', (done) => {
     const newOptions = global.app.services.SequelizeService.mergeOptionDefaults({
-      include: [{ target: 'model' }}]
+      include: [{ target: 'model' }]
     }, {
         include: [{ model: 'model' }]
     })

--- a/test/unit/services/SequelizeService.test.js
+++ b/test/unit/services/SequelizeService.test.js
@@ -2,7 +2,7 @@
 
 const assert = require('assert')
 
-describe.only('api.services.SequelizeService', () => {
+describe('api.services.SequelizeService', () => {
   it.skip('should do stringify sort', (done) => {
     const sort = [['created_at','ASC']]
     const s = global.app.services.SequelizeService.sortToString(sort)


### PR DESCRIPTION
- add third alternative format using association object

#### Description
- Fixed merge includes by changing associate property to association to follow the standard asssociation property format
- Add third format for include as shown below
```
include [
  <SequelizeAssociationObject>
]
```

#### Issues
- resolves ##19
