### PR TITLE
[feat] better plugs, model options and schema accessors

### DIFF
--- a/lib/SequelizeResolver.ts
+++ b/lib/SequelizeResolver.ts
@@ -4,6 +4,8 @@ import { Transformer } from './transformer'
 
 export class SequelizeResolver extends FabrixResolver {
   private _connection
+  private _options
+  private _schema
   private _sequelize
   private _sequelizeModel
 
@@ -35,6 +37,20 @@ export class SequelizeResolver extends FabrixResolver {
     return this._sequelize
   }
 
+  /**
+   * Get options provided to the model when connected
+   */
+  get options() {
+    return this._options
+  }
+
+  /**
+   * Get schema provided to the model when connected
+   */
+  get schame() {
+    return this._schema
+  }
+
   get datastore() {
     return this._sequelize
   }
@@ -44,6 +60,8 @@ export class SequelizeResolver extends FabrixResolver {
   }
 
   public connect(modelName, schema, options) {
+    this._options = options
+
     // Define the Sequelize Connection on the provided connection
     this._sequelizeModel = this._connection.define(modelName, schema, options)
 
@@ -248,7 +266,17 @@ export class SequelizeResolver extends FabrixResolver {
    */
   findById(id, options = { }) {
     if (this._sequelizeModel) {
-      return this._sequelizeModel.findById(id, options)
+      this.app.log.info('findById is deprecated, use findByPk instead')
+      return this._sequelizeModel.findByPk(id, options)
+    }
+  }
+
+  /**
+   *
+   */
+  findByPk(id, options = { }) {
+    if (this._sequelizeModel) {
+      return this._sequelizeModel.findByPk(id, options)
     }
   }
 

--- a/lib/schemas.ts
+++ b/lib/schemas.ts
@@ -2,9 +2,15 @@
 const joi = require('joi')
 
 export const Schemas = {
-  storesConfig: joi.object(),
-  modelsConfig: joi.object(),
-  pluginsConfig: joi.object(),
+  storesConfig: joi.object().keys({
+
+  }).unknown(),
+  modelsConfig: joi.object().keys({
+
+  }).unknown(),
+  pluginsConfig: joi.object().keys({
+
+  }).unknown(),
 
   models: joi.object().keys({
     autoPK: joi.boolean(),

--- a/lib/transformer.ts
+++ b/lib/transformer.ts
@@ -233,9 +233,17 @@ export const Transformer = {
     const Seq = Sequelize
 
     // Add plugins
-    plugs.forEach(plug => {
+    plugs.forEach((plug: any) => {
       try {
-        plug(Seq)
+        if (typeof plug === 'function') {
+          plug(Seq)
+        }
+        else if (typeof plug === 'object' && plug.func && plug.config) {
+          plug.func(Seq, plug.config)
+        }
+        else {
+          app.log.debug(`Transformer: ${plug} was not a function or Fabrix sequelize object`)
+        }
       }
       catch (err) {
         app.log.error(err)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@fabrix/spool-sequelize",
-  "version": "1.6.5",
+  "version": "1.6.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fabrix/spool-sequelize",
-  "version": "1.6.5",
+  "version": "1.6.6",
   "description": "Spool - Datastore Spool for Sequelize.js http://sequelizejs.com",
   "scripts": {
     "build": "tsc -p ./lib/tsconfig.release.json",

--- a/test/fixtures/app.js
+++ b/test/fixtures/app.js
@@ -224,7 +224,11 @@ const App = {
         host: '127.0.0.1',
         dialect: 'postgres',
         plugins: {
-          test_local: require('./testPlugin')
+          test_local: require('./testPlugin'),
+          test_local_config: {
+            func: require('./testPlugin2'),
+            config: {}
+          }
         }
       },
       storeoverride: {

--- a/test/fixtures/testPlugin2.js
+++ b/test/fixtures/testPlugin2.js
@@ -1,0 +1,8 @@
+module.exports = function(Sequelize, config) {
+  if (!Sequelize) {
+    Sequelize = require('sequelize')
+  }
+
+  // return Sequelize
+  return Sequelize
+}


### PR DESCRIPTION
#### Description
Plugins are now configurable instead of just requirable:

```js
eg. test: {
  func: require('my_plug'),
 config: { my_great_value: 123 }
}
```

results in `mplug(Sequelize, { my_great_value: 123 })`

This supports a greater variety of plugins.

Also, the resolver now exposes the model.options and model.schema as a get accessor.  This is useful in extending the functionality of a model in Fabrix and each ORM Resolver should do something similar.

#### Issues
- resolves none
