### PR TITLE
[feat] unified global sequelize

### DIFF
--- a/lib/SequelizeSpool.ts
+++ b/lib/SequelizeSpool.ts
@@ -73,9 +73,9 @@ export class SequelizeSpool extends DatastoreSpool {
   configure() {
     this._plugins = Transformer.getPlugins(this.app)
     // Holds a collection of the connections made through Sequelize
-    this._connections = Transformer.getConnections(this.app, this.plugins)
+    this._connections = Transformer.getConnections(this.app, this._datastore, this.plugins)
     // Holds a collection of the Sequelize models
-    this._models = Transformer.getModels(this.app, this.connections)
+    this._models = Transformer.getModels(this.app, this._datastore, this.connections)
   }
 
   /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@fabrix/spool-sequelize",
-  "version": "1.6.9",
+  "version": "1.6.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fabrix/spool-sequelize",
-  "version": "1.6.9",
+  "version": "1.6.10",
   "description": "Spool - Datastore Spool for Sequelize.js http://sequelizejs.com",
   "scripts": {
     "build": "tsc -p ./lib/tsconfig.release.json",

--- a/test/unit/lib/transformer.test.js
+++ b/test/unit/lib/transformer.test.js
@@ -2,6 +2,8 @@ const assert = require('assert')
 const lib = require('../../../dist/index')
 const FabrixApp = require('@fabrix/fabrix').FabrixApp
 
+const Sequelize = require('sequelize')
+
 describe('lib.Transformer', () => {
   let app
   beforeEach(() => {
@@ -11,21 +13,21 @@ describe('lib.Transformer', () => {
   describe('#getPlugins', () => {
     it('should transform properly', () => {
       const plugins = lib.Transformer.getPlugins(app)
-      const connections = lib.Transformer.getConnections(app, plugins)
-      const models = lib.Transformer.getModels(app, connections)
+      const connections = lib.Transformer.getConnections(app, Sequelize, plugins)
+      const models = lib.Transformer.getModels(app, Sequelize, connections)
       assert.ok(plugins)
     })
   })
 
   describe('#getConnections', () => {
     it('should transform properly', () => {
-      const connections = lib.Transformer.getConnections(app)
+      const connections = lib.Transformer.getConnections(app, Sequelize)
 
       assert(connections.teststore)
       assert.equal(connections.storeoverride.options.dialect, 'postgres')
     })
     it('should transform uri properly', () => {
-      const connections = lib.Transformer.getConnections(app)
+      const connections = lib.Transformer.getConnections(app, Sequelize)
       assert(connections.uristore)
       assert.equal(connections.uristore.options.dialect, 'sqlite')
       assert.equal(connections.uristore.options.host, 'testhost')
@@ -39,12 +41,12 @@ describe('lib.Transformer', () => {
   })
   describe('#getModels', () => {
     it('should transform properly', () => {
-      const connections = lib.Transformer.getConnections(app)
-      const models = lib.Transformer.getModels(app, connections)
+      const connections = lib.Transformer.getConnections(app, Sequelize)
+      const models = lib.Transformer.getModels(app, Sequelize, connections)
     })
     it('should not have a primary key for testModel3', () => {
-      const connections = lib.Transformer.getConnections(app)
-      const models = lib.Transformer.getModels(app, connections)
+      const connections = lib.Transformer.getConnections(app, Sequelize)
+      const models = lib.Transformer.getModels(app, Sequelize, connections)
     })
   })
 })

--- a/test/unit/services/SchemaMigrationService.test.js
+++ b/test/unit/services/SchemaMigrationService.test.js
@@ -3,6 +3,8 @@ const lib = require('../../../dist/index')
 const assert = require('assert')
 const FabrixApp = require('@fabrix/fabrix').FabrixApp
 const TestModel = require('../../fixtures/testmodel')
+const Sequelize = require('sequelize')
+
 const App = {
   pkg: {
     name: 'spool-sequelize-test'
@@ -45,8 +47,8 @@ describe('api.services.SchemaMigrationService', () => {
   beforeEach(() => {
     app = new FabrixApp(App)
     SchemaMigrationService = app.services.SchemaMigrationService
-    connections = lib.Transformer.getConnections(app) || {}
-    models = lib.Transformer.getModels(app, connections) || {}
+    connections = lib.Transformer.getConnections(app, Sequelize) || {}
+    models = lib.Transformer.getModels(app, Sequelize, connections) || {}
 
     it('should exist', () => {
       assert(SchemaMigrationService)


### PR DESCRIPTION
#### Description
Instead of importing Sequelize multiple times, the Transformer now uses the one supplied by the spool datastore.  This should help global import issues.

#### Issues
- resolves none.
